### PR TITLE
Patch 1

### DIFF
--- a/blocks.xml
+++ b/blocks.xml
@@ -10872,24 +10872,60 @@
   <!-- Final Stage - UHPC Concrete -->
 
   <block id="1423" name="uhpConcrete">
-      <property name="CustomIcon" value="ironWall"/>
-	<property name="CustomIconTint" value="FD9095"/>
-	<property name="Shape" value="CubeCutoutBackFaces" />
-    <property name="Mesh" value="cutout" />
-    <property name="Material" value="concrete_steel" />
-    <property name="Texture" value="176,176,176,176,176,176" />
+		<property name="Material" value="concrete_steel" />
+		<property name="Texture" value="176,176,176,176,176,176" />
 <!-- 	<property name="Texture" value="381" /> -->
-	<property class="UpgradeBlock">
+		<property class="UpgradeBlock">
 	<!-- LT Modified the block to new UHPC, was previously normal concrete form -->
-      <property name="ToBlock" value="steelWall" />
-      <property name="Item" value="forgedSteel" />
-      <property name="ItemCount" value="2" />
-      <property name="UpgradeHitCount" value="4" />
-    </property>
-    <property name="DowngradeBlock" value="concreteReinforcedBroke01" />
+			<property name="ToBlock" value="steelWall" />
+			<property name="Item" value="forgedSteel" />
+			<property name="ItemCount" value="2" />
+			<property name="UpgradeHitCount" value="4" />
+		</property>
+		<property name="DowngradeBlock" value="uhpConcreteBroke01" />
     <drop event="Destroy" count="0" prob="1" />
   </block>
   
+  
+  <block id="1430" name="uhpConcreteBroke01">
+    <property name="Material" value="concrete_steel" />
+    <property name="Texture" value="404" /> 
+    <property class="UpgradeBlock">
+      <property name="ToBlock" value="uhpConcrete" />
+      <property name="Item" value="uhpconcreteMix" />
+      <property name="ItemCount" value="1" />
+      <property name="UpgradeHitCount" value="1" />
+    </property>    
+    <property name="DowngradeBlock" value="uhpConcreteBroke02" />
+    <drop event="Destroy" count="0" />
+  </block>
+  
+  <block id="1431" name="uhpConcreteBroke02">
+	<property name="Material" value="concrete_steel" />
+	<property name="Texture" value="405" />
+	<property class="UpgradeBlock">
+		<property name="ToBlock" value="uhpConcreteBroke01" />
+		<property name="Item" value="uhpconcreteMix" />
+		<property name="ItemCount" value="1" />
+		<property name="UpgradeHitCount" value="1" />
+	</property>  
+	<property name="DowngradeBlock" value="uhpConcreteBroke03" />
+	<drop event="Destroy" count="0" />
+  </block>
+  
+<block id="1432" name="uhpConcreteBroke03">
+	<property name="Material" value="concrete_steel" />
+	<property name="Texture" value="406" />
+	<property class="UpgradeBlock">
+		<property name="ToBlock" value="uhpConcreteBroke02" />
+		<property name="Item" value="uhpconcreteMix" />
+		<property name="ItemCount" value="1" />
+		<property name="UpgradeHitCount" value="1" />
+	</property>          
+	<property name="DowngradeBlock" value="steelRebarFrame" />
+	<drop event="Destroy" count="0" />
+</block>
+
   <!-- SMELTER -->
   
       <!-- SMELTING MACHINE BUILD STAGE 1/2 - BUILT BUT UNPOWERED -->

--- a/items.xml
+++ b/items.xml
@@ -674,7 +674,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Repair_amount" value="2" />
             <property name="Upgrade_hit_offset" value="-2" />
             <property name="Sound_start" value="UseActions/repair_block" />
-            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron" />
+            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank" />
             <property name="Restricted_upgrade_items" value="concreteMix" />
         </property>
         <property name="Group" value="Tools/Traps" />
@@ -711,6 +711,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Repair_amount" value="2" />
             <property name="Upgrade_hit_offset" value="-1" />
             <property name="Sound_start" value="UseActions/repair_block" />
+            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank,ironOre,coalOre" />
             <property name="Restricted_upgrade_items" value="concreteMix" />
         </property>
         <property name="Group" value="Tools/Traps" />
@@ -6221,7 +6222,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Upgrade_hit_offset" value="-3" />
             <property name="Repair_action_sound" value="Weapons/Motorized/Nailgun/nailgun_fire" />
             <property name="Upgrade_action_sound" value="Weapons/Motorized/Nailgun/nailgun_fire" />
-            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron" />
+            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank" />
             <property name="Restricted_upgrade_items" value="concrete" />
         </property>
         <property name="Group" value="Ammo/Weapons" />

--- a/items.xml
+++ b/items.xml
@@ -619,7 +619,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Upgrade_hit_offset" value="0" />
             <property name="Sound_start" value="UseActions/repair_block" />
             <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron" />
-            <property name="Restricted_upgrade_items" value="concreteMix" />
+            <property name="Restricted_upgrade_items" value="concreteMix,uhpconcreteMix" />
         </property>
         <property name="Group" value="Tools/Traps" />
         <property class="Attributes">
@@ -675,7 +675,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Upgrade_hit_offset" value="-2" />
             <property name="Sound_start" value="UseActions/repair_block" />
             <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank" />
-            <property name="Restricted_upgrade_items" value="concreteMix" />
+            <property name="Restricted_upgrade_items" value="concreteMix,uhpconcreteMix" />
         </property>
         <property name="Group" value="Tools/Traps" />
         <property class="Preview">
@@ -712,7 +712,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Upgrade_hit_offset" value="-1" />
             <property name="Sound_start" value="UseActions/repair_block" />
             <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank,ironOre,coalOre" />
-            <property name="Restricted_upgrade_items" value="concreteMix" />
+            <property name="Restricted_upgrade_items" value="concreteMix,uhpconcreteMix" />
         </property>
         <property name="Group" value="Tools/Traps" />
         <property class="Preview">
@@ -6223,7 +6223,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Repair_action_sound" value="Weapons/Motorized/Nailgun/nailgun_fire" />
             <property name="Upgrade_action_sound" value="Weapons/Motorized/Nailgun/nailgun_fire" />
             <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank" />
-            <property name="Restricted_upgrade_items" value="concrete" />
+            <property name="Restricted_upgrade_items" value="concrete,concreteMix,uhpconcreteMix" />
         </property>
         <property name="Group" value="Ammo/Weapons" />
         <property class="Preview">


### PR DESCRIPTION
Added UHPConcrete downgrade blocks (previously downgraded to standard reinforced)
Added repair tools repairing new materials (and restricted repairing of uhpconcreteMix)
Set repair tool to be able to repair with ironOre,coalOre (instead of unrestricting everything) so that it cane be used to pack a smelter.
