### PR TITLE
Patch 1

### DIFF
--- a/blocks.xml
+++ b/blocks.xml
@@ -10711,7 +10711,7 @@
     <property name="Material" value="wood" />
     <property name="Shape" value="Tube" />
     <property name="Texture" value="21,21,116,116,116,116" />
-    <property name="FuelValue" value="192" />
+    <property name="FuelValue" value="384" />
     <property class="UpgradeBlock">
       <property name="ToBlock" value="reinforcedWoodTrunk" />
       <property name="Item" value="woodPlank" />

--- a/blocks.xml
+++ b/blocks.xml
@@ -10872,24 +10872,60 @@
   <!-- Final Stage - UHPC Concrete -->
 
   <block id="1423" name="uhpConcrete">
-      <property name="CustomIcon" value="ironWall"/>
-	<property name="CustomIconTint" value="FD9095"/>
-	<property name="Shape" value="CubeCutoutBackFaces" />
-    <property name="Mesh" value="cutout" />
-    <property name="Material" value="concrete_steel" />
-    <property name="Texture" value="176,176,176,176,176,176" />
+		<property name="Material" value="concrete_steel" />
+		<property name="Texture" value="176,176,176,176,176,176" />
 <!-- 	<property name="Texture" value="381" /> -->
-	<property class="UpgradeBlock">
+		<property class="UpgradeBlock">
 	<!-- LT Modified the block to new UHPC, was previously normal concrete form -->
-      <property name="ToBlock" value="steelWall" />
-      <property name="Item" value="forgedSteel" />
-      <property name="ItemCount" value="2" />
-      <property name="UpgradeHitCount" value="4" />
-    </property>
-    <property name="DowngradeBlock" value="concreteReinforcedBroke01" />
+			<property name="ToBlock" value="steelWall" />
+			<property name="Item" value="forgedSteel" />
+			<property name="ItemCount" value="2" />
+			<property name="UpgradeHitCount" value="4" />
+		</property>
+		<property name="DowngradeBlock" value="uhpConcreteBroke01" />
     <drop event="Destroy" count="0" prob="1" />
   </block>
   
+  
+  <block id="1430" name="uhpConcreteBroke01">
+    <property name="Material" value="concrete_steel" />
+    <property name="Texture" value="404" /> 
+    <property class="UpgradeBlock">
+      <property name="ToBlock" value="uhpConcrete" />
+      <property name="Item" value="uhpconcreteMix" />
+      <property name="ItemCount" value="1" />
+      <property name="UpgradeHitCount" value="1" />
+    </property>    
+    <property name="DowngradeBlock" value="uhpConcreteBroke02" />
+    <drop event="Destroy" count="0" />
+  </block>
+  
+  <block id="1431" name="uhpConcreteBroke02">
+	<property name="Material" value="concrete_steel" />
+	<property name="Texture" value="405" />
+	<property class="UpgradeBlock">
+		<property name="ToBlock" value="uhpConcreteBroke01" />
+		<property name="Item" value="uhpconcreteMix" />
+		<property name="ItemCount" value="1" />
+		<property name="UpgradeHitCount" value="1" />
+	</property>  
+	<property name="DowngradeBlock" value="uhpConcreteBroke03" />
+	<drop event="Destroy" count="0" />
+  </block>
+  
+<block id="1432" name="uhpConcreteBroke03">
+	<property name="Material" value="concrete_steel" />
+	<property name="Texture" value="406" />
+	<property class="UpgradeBlock">
+		<property name="ToBlock" value="uhpConcreteBroke02" />
+		<property name="Item" value="uhpconcreteMix" />
+		<property name="ItemCount" value="1" />
+		<property name="UpgradeHitCount" value="1" />
+	</property>          
+	<property name="DowngradeBlock" value="steelRebarFrame" />
+	<drop event="Destroy" count="0" />
+</block>
+
   <!-- SMELTER -->
   
       <!-- SMELTING MACHINE BUILD STAGE 1/2 - BUILT BUT UNPOWERED -->

--- a/items.xml
+++ b/items.xml
@@ -674,7 +674,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Repair_amount" value="2" />
             <property name="Upgrade_hit_offset" value="-2" />
             <property name="Sound_start" value="UseActions/repair_block" />
-            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron" />
+            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank" />
             <property name="Restricted_upgrade_items" value="concreteMix" />
         </property>
         <property name="Group" value="Tools/Traps" />
@@ -711,6 +711,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Repair_amount" value="2" />
             <property name="Upgrade_hit_offset" value="-1" />
             <property name="Sound_start" value="UseActions/repair_block" />
+            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank,ironOre,coalOre" />
             <property name="Restricted_upgrade_items" value="concreteMix" />
         </property>
         <property name="Group" value="Tools/Traps" />
@@ -6221,7 +6222,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Upgrade_hit_offset" value="-3" />
             <property name="Repair_action_sound" value="Weapons/Motorized/Nailgun/nailgun_fire" />
             <property name="Upgrade_action_sound" value="Weapons/Motorized/Nailgun/nailgun_fire" />
-            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron" />
+            <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank" />
             <property name="Restricted_upgrade_items" value="concrete" />
         </property>
         <property name="Group" value="Ammo/Weapons" />

--- a/items.xml
+++ b/items.xml
@@ -619,7 +619,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Upgrade_hit_offset" value="0" />
             <property name="Sound_start" value="UseActions/repair_block" />
             <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron" />
-            <property name="Restricted_upgrade_items" value="concreteMix" />
+            <property name="Restricted_upgrade_items" value="concreteMix,uhpconcreteMix" />
         </property>
         <property name="Group" value="Tools/Traps" />
         <property class="Attributes">
@@ -675,7 +675,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Upgrade_hit_offset" value="-2" />
             <property name="Sound_start" value="UseActions/repair_block" />
             <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank" />
-            <property name="Restricted_upgrade_items" value="concreteMix" />
+            <property name="Restricted_upgrade_items" value="concreteMix,uhpconcreteMix" />
         </property>
         <property name="Group" value="Tools/Traps" />
         <property class="Preview">
@@ -712,7 +712,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Upgrade_hit_offset" value="-1" />
             <property name="Sound_start" value="UseActions/repair_block" />
             <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank,ironOre,coalOre" />
-            <property name="Restricted_upgrade_items" value="concreteMix" />
+            <property name="Restricted_upgrade_items" value="concreteMix,uhpconcreteMix" />
         </property>
         <property name="Group" value="Tools/Traps" />
         <property class="Preview">
@@ -6223,7 +6223,7 @@ ARMOR ATTRIBUTE EXAMPLE
             <property name="Repair_action_sound" value="Weapons/Motorized/Nailgun/nailgun_fire" />
             <property name="Upgrade_action_sound" value="Weapons/Motorized/Nailgun/nailgun_fire" />
             <property name="Allowed_upgrade_items" value="woodPlank,scrapIron,forgedIron,hardwoodPlank" />
-            <property name="Restricted_upgrade_items" value="concrete" />
+            <property name="Restricted_upgrade_items" value="concrete,concreteMix,uhpconcreteMix" />
         </property>
         <property name="Group" value="Ammo/Weapons" />
         <property class="Preview">

--- a/materials.xml
+++ b/materials.xml
@@ -575,26 +575,26 @@
    
    	
 			<!-- LT Steel / Concrete Hybrid -->
-    <material id="concrete_steel" 
-        damage_category="metal"
-        surface_category="metal"
-        hardness="300.0"
-        stepsound="metal"
-		stability_glue="210"
-		mass="25"
-		explosionresistance=".2"
-    />	
+   <material id="concrete_steel">
+      <property name="damage_category" value="metal" />
+      <property name="surface_category" value="metal" />
+      <property name="Hardness" type="float" value="300.0" />
+      <property name="stepsound" value="metal" />
+      <property name="stability_glue" value="210" />
+      <property name="Mass" type="int" value="25" />
+      <property name="explosionresistance" value=".2" />
+   </material>
 	
 				<!-- LT Tungsten / Concrete Hybrid -->
-    <material id="concrete_tungsten" 
-        damage_category="tungsten"
-        surface_category="tungsten"
-        hardness="40.0"
-        stepsound="metal"
-		stability_glue="240"
-		mass="30"
-		explosionresistance=".1"
-    />	
+   <material id="concrete_tungsten">
+      <property name="damage_category" value="tungsten" />
+      <property name="surface_category" value="tungsten" />
+      <property name="Hardness" type="float" value="40.0" />
+      <property name="stepsound" value="metal" />
+      <property name="stability_glue" value="240" />
+      <property name="Mass" type="int" value="30" />
+      <property name="explosionresistance" value=".1" />
+   </material>
    
    
    


### PR DESCRIPTION
Fixed repair tools to repair new materials/blocks
Added restrictions on uhpconcreteMix so it's treated like normal concreteMix (must be poured from bucket, not repaired)
Added ironOre,coalOre to repair tool repair materials so they can still upgrade the smelter
Added uhpConcrete degrade blocks as it was set to downgrade to normal reinforcedConcrete blocks, breaking the uhpConcrete block tree.
Reformatted XML of materials.xml for the concrete_steel and concrete_tungsten hybrids, uhpConcrete was instantly breaking so may have been defaulting to a generic material somehow, only thing I could find out of place was the formatting (even though it looked like valid XML)

*\* Merged your updates to car spawning and potassium nitrate drops into my patch
